### PR TITLE
Open images with system's default image viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+temp.jpg

--- a/otaku.py
+++ b/otaku.py
@@ -4,11 +4,17 @@
 from jikanpy import Jikan # Jikan API wrapper
 from requests import get # To download images
 from os import system # To clear screen
+import platform
 
 jikan = Jikan() # Initializing the Jikan instance
 
 # Replace this with your command
-image_viewing_command = 'feh temp.jpg'
+if platform.system() == "Darwin":
+    image_viewing_command = 'open temp.jpg'
+elif platform.system() == "Linux":
+    image_viewing_command = 'xdg-open temp.jpg'
+else:
+    image_viewing_command = 'feh temp.jpg'
 
 # FUNCTIONS
 # Search for anime/manga/character
@@ -148,7 +154,7 @@ def check_info(search_type, query):
                 for chunk in response.iter_content(chunk_size=1024):
                     file.write(chunk)
             system(image_viewing_command) # Display Image
-            system('rm temp.jpg')
+            #system('rm temp.jpg') #this command will remove the image too fast for macOS to display it
             break
         elif choice == 'n':
             break

--- a/otaku.py
+++ b/otaku.py
@@ -156,7 +156,6 @@ def check_info(search_type, query):
                 for chunk in response.iter_content(chunk_size=1024):
                     file.write(chunk)
             system(image_viewing_command) # Display Image
-            #system('rm temp.jpg') #this command will remove the image too fast for macOS to display it
             break
         elif choice == 'n':
             break

--- a/otaku.py
+++ b/otaku.py
@@ -132,8 +132,14 @@ def check_info(search_type, query):
     elif search_type == 'character':
         character = jikan.character(query['mal_id'])
         print(f'Name             | {character["name"]}')
-        print(f'Animeography     | {character["animeography"][0]["name"]}')
-        print(f'Mangaography     | {character["mangaography"][0]["name"]}')
+        if len(character["animeography"]) > 0:
+            print(f'Animeography     | {character["animeography"][0]["name"]}')
+        else:
+            print("Animeography     | None")
+        if len(character["mangaography"]) > 0:
+            print(f'Mangaography     | {character["mangaography"][0]["name"]}')
+        else:
+            print("Mangaography     | None")
         print('---------------------------------------------')
         print(f'Nicknames        | {character["nicknames"]}')
         print(f'Member Favorites | {character["member_favorites"]}')

--- a/otaku.py
+++ b/otaku.py
@@ -3,7 +3,7 @@
 # MODULES
 from jikanpy import Jikan # Jikan API wrapper
 from requests import get # To download images
-from os import system # To clear screen
+from os import system, path # To clear screen and check for temp.jpg
 import platform
 
 jikan = Jikan() # Initializing the Jikan instance
@@ -243,10 +243,8 @@ while True:
         clear()
     elif choice in ['q', 'exit']:
         if platform.system == "Windows":
-            try: #added the try bc I dont know how to only delete file if it exists in Windows
+            if path.exists("temp.jpg"):
                 system("del temp.jpg")
-            except:
-                pass #nothing to do, file doesn't exist
         else:
             system("rm -f temp.jpg")
         exit()

--- a/otaku.py
+++ b/otaku.py
@@ -242,7 +242,13 @@ while True:
     elif choice == 'clear': # Clear the Screen
         clear()
     elif choice in ['q', 'exit']:
-        system("rm temp.jpg")
+        if platform.system == "Windows":
+            try: #added the try bc I dont know how to only delete file if it exists in Windows
+                system("del temp.jpg")
+            except:
+                pass #nothing to do, file doesn't exist
+        else:
+            system("rm -f temp.jpg")
         exit()
     else:
         print('Invalid Command...')

--- a/otaku.py
+++ b/otaku.py
@@ -13,8 +13,10 @@ if platform.system() == "Darwin":
     image_viewing_command = 'open temp.jpg'
 elif platform.system() == "Linux":
     image_viewing_command = 'xdg-open temp.jpg'
+elif platform.system() == "Windows":
+    image_viewing_command = 'start temp.jpg'
 else:
-    image_viewing_command = 'feh temp.jpg'
+    image_viewing_command = ''
 
 # FUNCTIONS
 # Search for anime/manga/character

--- a/otaku.py
+++ b/otaku.py
@@ -237,6 +237,7 @@ while True:
     elif choice == 'clear': # Clear the Screen
         clear()
     elif choice in ['q', 'exit']:
+        system("rm temp.jpg")
         exit()
     else:
         print('Invalid Command...')


### PR DESCRIPTION
With this change otaku.py will determine the platform it is running on and automatically decide on the right command to open the image. The chosen command will then open the image in the system's default image viewer. I have also decided to move the deletion of the temp.jpg file to the bottom of the program, as it can cause problems on macOS and potentially other image viewers that automatically reload the image file.

This should work on all reasonably up-to-date Windows and macOS systems, as well as on Linux systems with xdg-utils. I have tested my changes on Windows 10, macOS Big Sur and Arch Linux.

Edit: README should probably be changed to reflect this behavior.